### PR TITLE
Allow for testing exception messages using pytest.mark.raises

### DIFF
--- a/pytest_raises/pytest_raises.py
+++ b/pytest_raises/pytest_raises.py
@@ -3,8 +3,14 @@ import sys
 
 import pytest
 
+
 class ExpectedException(Exception):
     pass
+
+
+class ExpectedMessage(Exception):
+    pass
+
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
@@ -13,11 +19,23 @@ def pytest_runtest_call(item):
     if raises_marker:
         exception = raises_marker.kwargs.get('exception')
         exception = exception or Exception
+        message = raises_marker.kwargs.get('message')
 
         raised_exception = outcome.excinfo[1] if outcome.excinfo else None
         traceback = outcome.excinfo[2] if outcome.excinfo else None
         if isinstance(raised_exception, exception):
             outcome.force_result(None)
+            if message is not None:
+                try:
+                    raised_message = str(raised_exception)
+                    if message not in raised_message:
+                        raise ExpectedMessage('"{}" not in "{}"'.format(message, raised_message))
+                except(ExpectedMessage):
+                    excinfo = sys.exc_info()
+                    if traceback:
+                        outcome.excinfo = excinfo[:2] + (traceback, )
+                    else:
+                        outcome.excinfo = excinfo
         else:
             try:
                 raise raised_exception or ExpectedException('Expected exception {}, but it did not raise'.format(exception))

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -125,7 +125,7 @@ def test_pytest_mark_raises_parametrize(testdir):
             '*::test_mark_raises*error3* PASSED',
             '*::test_mark_raises*error4* FAILED',
             '*::test_mark_raises*error5* FAILED',
-            '*::test_mark_raises*6None* FAILED',
+            '*::test_mark_raises*None* FAILED',
         ],
         1
     )

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -113,6 +113,8 @@ def test_pytest_mark_raises_parametrize(testdir):
                 pytest.mark.raises(AnotherException('the message'), exception=SomeException),
                 SomeException('the message'),
                 pytest.mark.raises(None, exception=SomeException),
+                pytest.mark.raises(SomeException('the message'), exception=SomeException, message='the message'),
+                pytest.mark.raises(SomeException('the message'), exception=SomeException, message='other message'),
             ])
             def test_mark_raises(error):
                 if error:
@@ -126,6 +128,9 @@ def test_pytest_mark_raises_parametrize(testdir):
             '*::test_mark_raises*error4* FAILED',
             '*::test_mark_raises*error5* FAILED',
             '*::test_mark_raises*None* FAILED',
+            '*::test_mark_raises*error7* PASSED',
+            '*::test_mark_raises*error8* FAILED',
+            '*ExpectedMessage: "other message" not in "the message"',
         ],
         1
     )


### PR DESCRIPTION
This PR allows for testing if an exception raised contains a certain message as is discussed in #5. It does a simple check now to see whether the expected message is part of the raised exception message by using `in` comparison.