### PR TITLE
Use static pytest and pylint versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ def write_version():
 def get_version():
     file_version = _get_version_from_file()
     git_version = _get_version_from_git()
-    return (file_version == 'development' and git_version) or file_version
+    return git_version if (file_version == 'development' and git_version) else file_version
 
 def get_data_files():
     data_files = []
@@ -100,11 +100,11 @@ def main():
             'sdist'         : CustomSDistCommand,
         },
         install_requires    = [
-            'pytest>=2.8.1'
+            'pytest==3.2.2'
         ],
         extras_require      = {
             'develop'       : [
-                'pylint>=1.5.5',
+                'pylint==1.7.2',
             ],
         },
         packages            = [

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -119,13 +119,13 @@ def test_pytest_mark_raises_parametrize(testdir):
                     raise error
         """,
         [
-            '*::test_mark_raises*None* PASSED',
+            '*::test_mark_raises*None0* PASSED',
             '*::test_mark_raises*error1* PASSED',
             '*::test_mark_raises*error2* PASSED',
             '*::test_mark_raises*error3* PASSED',
             '*::test_mark_raises*error4* FAILED',
             '*::test_mark_raises*error5* FAILED',
-            '*::test_mark_raises*6None* FAILED',
+            '*::test_mark_raises*None1* FAILED',
         ],
         1
     )


### PR DESCRIPTION
This will ensure pylint and tests don't break because of unknown
version updates.

Also fix what was causing the pylint error which brought this up in the
first place.