### PR TITLE
Compatibility with pytest 3.6+

### DIFF
--- a/pytest_raises/pytest_raises.py
+++ b/pytest_raises/pytest_raises.py
@@ -15,7 +15,7 @@ class ExpectedMessage(Exception):
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     outcome = yield
-    raises_marker = item.get_marker('raises')
+    raises_marker = item.get_closest_marker('raises')
     if raises_marker:
         exception = raises_marker.kwargs.get('exception')
         exception = exception or Exception

--- a/pytest_raises/pytest_raises.py
+++ b/pytest_raises/pytest_raises.py
@@ -15,7 +15,14 @@ class ExpectedMessage(Exception):
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_call(item):
     outcome = yield
-    raises_marker = item.get_closest_marker('raises')
+
+    # Pytest 3.5+ has a new function for getting a maker from a node
+    # In order to maintain compatability, prefer the newer function
+    # (get_closest_marker) but use the old function (get_marker) if it
+    # doesn't exist.
+    marker_get_func = item.get_closest_marker if hasattr(item, 'get_closest_marker') else item.get_marker
+
+    raises_marker = marker_get_func('raises')
     if raises_marker:
         exception = raises_marker.kwargs.get('exception')
         exception = exception or Exception


### PR DESCRIPTION
I recently got the following deprecation warning when using `pytest-raises` with the latest `pytest`:
```
/home/mattb/git/airflow/airflow-wrappers/venv/x3/lib/python3.6/site-packages/pytest_raises/pytest_raises.py:20: RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
Please use node.get_closest_marker(name) or node.iter_markers(name).
Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
  exception = raises_marker.kwargs.get('exception')
/home/mattb/git/airflow/airflow-wrappers/venv/x3/lib/python3.6/site-packages/pytest_raises/pytest_raises.py:22: RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
Please use node.get_closest_marker(name) or node.iter_markers(name).
Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
  message = raises_marker.kwargs.get('message')
```
Pytest version:
```
 mattb  (e) airflow-wrappers   feature/MDA-111-wrapper-trigger-per-cell-dags  ~  git  airflow  airflow-wrappers  pytest --version
This is pytest version 3.6.0, imported from /home/mattb/programs/anaconda3/envs/airflow-wrappers/lib/python3.6/site-packages/pytest.py
setuptools registered plugins:
  pytest-raises-0.8 at /home/mattb/programs/anaconda3/envs/airflow-wrappers/lib/python3.6/site-packages/pytest_raises/pytest_raises.py
```

Pytest has a guide for upgrading markers, which is what I followed: https://docs.pytest.org/en/latest/mark.html#updating-code

All unit tests passed on my local machine, let me know if there's anything else I need to add!