### PR TITLE
docker update, setup_raises, match argument, "coverage"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ python:
 - "nightly"
 install:
 - pip install pip -U
-- pip install .[develop]
+- pip install -e .[develop]
 script:
-- py.test
+- py.test --cov-report term-missing --cov-report xml:coverage.xml --cov
 - ./pylint.sh
 deploy:
   provider: pypi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
 FROM python:3.6-alpine
 
 RUN apk add --no-cache git
+# gcc and musl-dev now required to build pylint's dependencies since
+# python:3.6-alpine does not satisfy 'manylinux' distribution.
+# See: https://github.com/PyCQA/pylint/issues/2291
+RUN apk add gcc musl-dev
 
-COPY . /src/pytest-raises
+# Install dependencies first before copying full tree so docker does not
+# re-install everything each time a test file is changed.  If setup.py changes
+# dependencies, these must be updated as well!
+RUN mkdir -p /src/pytest-raises
+RUN python3 -m pip install pytest>=3.2.2
+RUN python3 -m pip install pylint==1.7.2
 
+# Changes to source should have docker build cached up to here
 WORKDIR /src/pytest-raises
-
-RUN pip install .[develop]
+COPY . /src/pytest-raises
+RUN python3 -m pip install .[develop]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apk add gcc musl-dev
 RUN mkdir -p /src/pytest-raises
 RUN python3 -m pip install pytest>=3.2.2
 RUN python3 -m pip install pylint==1.7.2
+RUN python3 -m pip install pytest-cov
 
 # Changes to source should have docker build cached up to here
 WORKDIR /src/pytest-raises
 COPY . /src/pytest-raises
-RUN python3 -m pip install .[develop]
+RUN python3 -m pip install -e .[develop]

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,5 @@ build:
 	docker build . -t pytest-raises:dev
 
 test: build
-	docker run --rm -it pytest-raises:dev py.test
+	docker run --rm -it pytest-raises:dev py.test --cov-report term-missing --cov
 	docker run --rm -it pytest-raises:dev sh -c /src/pytest-raises/pylint.sh

--- a/pylint.sh
+++ b/pylint.sh
@@ -1,8 +1,3 @@
-PYTHON36=$(python -c 'import sys; print(sys.version_info[0] == 3 and sys.version_info[1] > 5 )')
-if [ "$PYTHON36" == "True" ]; then
-    exit 0
-fi
-
 set -x
 PROJECT=pytest_raises
 if [ -z "$1" ]; then

--- a/pylintrc
+++ b/pylintrc
@@ -277,7 +277,7 @@ max-locals=15
 max-returns=6
 
 # Maximum number of branch for function / method body
-max-branches=12
+max-branches=13
 
 # Maximum number of statements in function / method body
 max-statements=50

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-norecursedirs = build ve

--- a/pytest_raises/pytest_raises.py
+++ b/pytest_raises/pytest_raises.py
@@ -5,16 +5,16 @@ import sys
 import pytest
 
 
-class ExpectedException(Exception):
-    pass
+class ExpectedException(Exception):       # pragma: no cover
+    pass                                  # pragma: no cover
 
 
-class ExpectedMessage(Exception):
-    pass
+class ExpectedMessage(Exception):         # pragma: no cover
+    pass                                  # pragma: no cover
 
 
-class PytestRaisesUsageError(Exception):
-    pass
+class PytestRaisesUsageError(Exception):  # pragma: no cover
+    pass                                  # pragma: no cover
 
 
 def _pytest_fail_by_mark_or_set_excinfo(item, outcome, marker_name, ExceptionClass, failure_message, traceback):
@@ -99,7 +99,7 @@ def _pytest_fail_by_mark_or_set_excinfo(item, outcome, marker_name, ExceptionCla
                         # pylint: disable=protected-access
                         outcome._excinfo = excinfo
                     # pylint: disable=bare-except
-                    except:
+                    except:  # pragma: no cover (no tests hit this, kept for safety).
                         pytest.fail(failure_message, pytrace=False)
 
 

--- a/pytest_raises/pytest_raises.py
+++ b/pytest_raises/pytest_raises.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import re
 import sys
 
 import pytest
@@ -12,43 +13,278 @@ class ExpectedMessage(Exception):
     pass
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_call(item):
-    outcome = yield
+class PytestRaisesUsageError(Exception):
+    pass
 
+
+def _pytest_fail_by_mark_or_set_excinfo(item, outcome, marker_name, ExceptionClass, failure_message, traceback):
+    """
+    Defer a test failure to a later stage, or set ``excinfo`` of ``outcome``, depending
+    on ``marker_name``.  This function should only be called for test items that have
+    failed -- the end result of calling this function for *any* ``item`` / ``outcome``
+    is that the test will fail.
+
+    .. warning::
+
+        **This is a "private" function not intended to be called directly by external projects!**
+
+    Depending on the stage at which this function is called, one of two actions will
+    be performed:
+
+    1. ``marker_name='setup_raises'``: a "secret" marker will be added to ``item``
+       indicating that the test failed.  This marker is then checked at a later stage
+       when it is safe to fail.  See documentation for :func:`_pytest_raises_validation`
+       for more information.
+    2. ``marker_name='raises'``: the ``outcome.excinfo`` will be populated with an
+       exception traceback that will eventually (through ``pytest``) mark the test as
+       failed.
+
+    **Parameters**
+
+    ``item``
+        The ``pytest`` test item, e.g., what is supplied to
+        ``pytest_runtest_setup(item)`` or ``pytest_runtest_call(item)``.
+
+    ``outcome``
+        The ``pytest`` test outcome for the ``@pytest.hookimpl(hookwrapper=True)`` hook
+        wrappers, where ``outcome = yield``.
+
+    ``marker_name``
+        The string marker name.  Values are **assumed** to be ``'setup_raises'`` or
+        ``'raises'`` **only**.
+
+        - ``'setup_raises'``: call originates from ``pytest_runtest_setup`` hook wrapper.
+        - ``'raises'``: call originates from ``pytest_runtest_call`` hook wrapper.
+
+    ``ExceptionClass``
+        The exception class to re-raise.  Expected to be :class:`ExpectedException` or
+        :class:`ExpectedMessage`, but not strictly required.
+
+    ``failure_message``
+        The string failure message to mark with or re-raise, depending on the value
+        of ``marker_name``.
+
+    ``traceback``
+        The traceback information if available, ``None`` otherwise.
+    """
+    # pylint: disable=unused-variable
+    __tracebackhide__ = True
+    if marker_name == 'setup_raises':
+        # In the later stage when `fail` is called, it is nice to "simulate" an
+        # exception by putting the expected exception class's name as a prefix.
+        failure_message = '{}: {}'.format(ExceptionClass.__name__, failure_message)
+        item.add_marker(pytest.mark.setup_raises_expected_exc_or_message_not_found(failure_message))
+    else:  # marker_name == 'raises'
+        # Avoid "while handling exception another exception occurred" scenarios.
+        if issubclass(ExceptionClass, PytestRaisesUsageError):
+            failure_message = '{}: {}'.format(ExceptionClass.__name__, failure_message)
+            pytest.fail(failure_message, pytrace=False)
+        else:
+            try:
+                raise ExceptionClass(failure_message)
+            except(ExceptionClass):
+                # 1. Try and set ``outcome.excinfo``.
+                # 2. Sometimes (unknown when) ``outcome.excinfo`` will trigger an
+                #    AttributeError even when the test raised.  So try and set the
+                #    undocumented ``outcome._excinfo`` attribute instead.
+                # 3. If setting ``outcome._excinfo`` fails, fallback on ``pytest.fail``.
+                excinfo = sys.exc_info()
+                if traceback:
+                    excinfo = excinfo[:2] + (traceback, )
+                try:
+                    outcome.excinfo = excinfo
+                # pylint: disable=bare-except
+                except:
+                    try:
+                        # pylint: disable=protected-access
+                        outcome._excinfo = excinfo
+                    # pylint: disable=bare-except
+                    except:
+                        pytest.fail(failure_message, pytrace=False)
+
+
+def _pytest_raises_validation(item, outcome, marker_name):
+    """
+    Validate that the test ``item`` and corresponding ``outcome`` raised an exception
+    of the correct class, and if supplied the exception message was as expected.  A
+    given test that has been marked with either ``@pytest.mark.setup_raises`` or
+    ``@pytest.mark.raises`` can fail in one of three ways:
+
+    1. The test raised an exception of the correct exception class, but the exception
+       message did not match what was specified using either ``message`` or ``match``
+       parameters.
+    2. The test raised an exception of the incorrect exception class (as specified by
+       the ``exception`` argument).
+    3. The test was marked with either ``@pytest.mark.setup_raises`` or
+       ``@pytest.mark.raises``, but no exception was raised.
+
+    In order to support hook wrappers for both ``pytest_runtest_setup`` and
+    ``pytest_runtest_call``, a "handshake" must be performed using a "secret" marker.
+    This handshake is only possible because this extension implements a hook wrapper
+    for both ``pytest_runtest_setup`` and ``pytest_runtest_call``.  To better explain
+    the handshake, we first examine the ``pytest_runtest_call`` hook wrapper.
+
+    ``@pytest.mark.raises(...)`` execution:
+
+        1. The test is run (``outcome = yield``).
+        2. This method is called.  If any of the three cases above that indicate failure
+           happen, the test is failed.
+        3. The test is failed by calling :func:`_pytest_fail_by_mark_or_set_excinfo`,
+           which in this case will set ``outcome.excinfo``.
+        4. By setting ``outcome.excinfo``, ``pytest`` will take over at a later stage
+           and report the test as failed with our message.
+
+    ``@pytest.mark.setup_raises(...)`` execution:
+
+        1. The test *setup* is run (``outcome = yield``).
+        2. This method is called, If any of the three cases above that indicate failure
+           happen, the test is *marked* for failure.
+        3. The test is failed by calling :func:`_pytest_fail_by_mark_or_set_excinfo`,
+           which adds a "secret" marker that includes the failure message.
+        4. Officially, the entire ``pytest_runtest_setup`` phase is completed without
+           any formal failure by this extension.
+        5. The ``pytest_runtest_call`` is triggered by ``pytest``, and this method is
+           called again.
+        6. The "secret" marker is detected, and an explicit invocation of
+           ``pytest.fail`` is issued, ultimately failing the test.
+
+    This process is unfortunately a little contrived.  However, it is done this way
+    because this extension needs to be able to mark tests as failed, not error.  For
+    reasons unknown to the author, any of the following issued during the
+    ``pytest_runtest_setup`` hook wrapper will cause the test to **ERROR** rather than
+    **FAIL**:
+
+    - Setting ``outcome.excinfo``: during the setup phase this is a write protected
+      attribute.
+    - Issuing ``pytest.fail(...)``: a call to ``pytest.fail(...)`` during the setup
+      phase will trigger a test **error** rather than a failure.
+
+    .. note::
+
+        The use of this handshake has an important implication!  Since the "secret"
+        marker must be checked for first in order to fail out early, this means that
+        marking a test case with **both** ``@pytest.mark.setup_raises`` and
+        ``@pytest.mark.raises`` **cannot** be supported.  In practice, this should not
+        be done (it does not make sense, if your setup fails you cannot run the test
+        reliably).
+
+    **Parameters**
+
+    ``item``
+        The ``pytest`` test item, e.g., what is supplied to
+        ``pytest_runtest_setup(item)`` or ``pytest_runtest_call(item)``.
+
+    ``outcome``
+        The ``pytest`` test outcome for the ``@pytest.hookimpl(hookwrapper=True)`` hook
+        wrappers, where ``outcome = yield``.
+
+    ``marker_name``
+        The string marker name.  Values are **assumed** to be ``'setup_raises'`` or
+        ``'raises'`` **only**.
+
+        - ``'setup_raises'``: call originates from ``pytest_runtest_setup`` hook wrapper.
+        - ``'raises'``: call originates from ``pytest_runtest_call`` hook wrapper.
+    """
+    # pylint: disable=unused-variable
+    __tracebackhide__ = True
     # Pytest 3.5+ has a new function for getting a maker from a node
     # In order to maintain compatability, prefer the newer function
     # (get_closest_marker) but use the old function (get_marker) if it
     # doesn't exist.
     marker_get_func = item.get_closest_marker if hasattr(item, 'get_closest_marker') else item.get_marker
 
-    raises_marker = marker_get_func('raises')
+    # Short-circuit: if the "secret" marker is found, then this test failed during setup
+    # and it is now safe to ``pytest.fail`` without causing an ERROR.
+    secret_marker = marker_get_func('setup_raises_expected_exc_or_message_not_found')
+    if secret_marker:
+        # NOTE: pytrace=False because the existing call stack is unrelated to the
+        # original failure processed during `pytest_runtest_setup` hook wrapper.
+        pytest.fail(secret_marker.args[0], pytrace=False)
+
+    raises_marker = marker_get_func(marker_name)
     if raises_marker:
-        exception = raises_marker.kwargs.get('exception')
-        exception = exception or Exception
-        message = raises_marker.kwargs.get('message')
+        exception = raises_marker.kwargs.get('exception', Exception)
+        try:
+            if not issubclass(exception, BaseException):
+                failure_message = '@pytest.mark.{0}: supplied `exception={1}` is not a subclass of `BaseException`.'.format(
+                    marker_name, exception
+                )
+                _pytest_fail_by_mark_or_set_excinfo(
+                    item, outcome, marker_name, PytestRaisesUsageError, failure_message, None
+                )
+                return
+        except TypeError:
+            failure_message = '@pytest.mark.{}: supplied `exception` argument must be a Class, e.g., `exception=RuntimeError`.'.format(
+                marker_name
+            )
+            _pytest_fail_by_mark_or_set_excinfo(
+                item, outcome, marker_name, PytestRaisesUsageError, failure_message, None
+            )
+            return
+
+        message = raises_marker.kwargs.get('message', None)
+        match_pattern = raises_marker.kwargs.get('match', None)
+        match_flags = raises_marker.kwargs.get('match_flags', 0)  # 0 means no flags for `re.match`
+
+        # Only `message` or `match` should be supplied at a time, not both.
+        if message and match_pattern:
+            failure_message = '@pytest.mark.{}: only `message="{}"` *OR* `match="{}"` allowed, not both.'.format(
+                marker_name, message, match_pattern
+            )
+            _pytest_fail_by_mark_or_set_excinfo(
+                item, outcome, marker_name, PytestRaisesUsageError, failure_message, None
+            )
+            return
 
         raised_exception = outcome.excinfo[1] if outcome.excinfo else None
         traceback = outcome.excinfo[2] if outcome.excinfo else None
+
+        # This plugin needs to work around the other hooks, see:
+        # https://docs.pytest.org/en/latest/writing_plugins.html#hookwrapper-executing-around-other-hooks
+        outcome.force_result(None)
+
+        # Case 1: test raised exception is correct class (or derived type), check
+        # message if provided by user.
         if isinstance(raised_exception, exception):
-            outcome.force_result(None)
+            raised_message = str(raised_exception)
+            failure_message = None
             if message is not None:
-                try:
-                    raised_message = str(raised_exception)
-                    if message not in raised_message:
-                        raise ExpectedMessage('"{}" not in "{}"'.format(message, raised_message))
-                except(ExpectedMessage):
-                    excinfo = sys.exc_info()
-                    if traceback:
-                        outcome.excinfo = excinfo[:2] + (traceback, )
-                    else:
-                        outcome.excinfo = excinfo
+                if message not in raised_message:
+                    failure_message = '"{}" not in "{}"'.format(message, raised_message)
+            elif match_pattern is not None:
+                if not re.match(match_pattern, raised_message, match_flags):
+                    failure_message = '"{}" does not match raised message "{}"'.format(match_pattern, raised_message)
+            if failure_message:
+                _pytest_fail_by_mark_or_set_excinfo(
+                    item, outcome, marker_name, ExpectedMessage, failure_message, traceback
+                )
+        # Case 2: test raised exception, but it was of an unexpected type.
+        elif raised_exception:
+            failure_message = 'Expected exception of type {}, but got exception of type {} with message: {}'.format(
+                exception, type(raised_exception), str(raised_exception)
+            )
+            _pytest_fail_by_mark_or_set_excinfo(
+                item, outcome, marker_name, ExpectedException, failure_message, traceback
+            )
+        # Case 3: test did _not_ raise exception, but was expected to.
         else:
-            try:
-                raise raised_exception or ExpectedException('Expected exception {}, but it did not raise'.format(exception))
-            except(ExpectedException):
-                excinfo = sys.exc_info()
-                if traceback:
-                    outcome.excinfo = excinfo[:2] + (traceback, )
-                else:
-                    outcome.excinfo = excinfo
+            failure_message = 'Expected exception {}, but it did not raise'.format(exception)
+            _pytest_fail_by_mark_or_set_excinfo(
+                item, outcome, marker_name, ExpectedException, failure_message, traceback
+            )
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    # pylint: disable=unused-variable
+    __tracebackhide__ = True
+    outcome = yield
+    _pytest_raises_validation(item, outcome, 'setup_raises')
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    # pylint: disable=unused-variable
+    __tracebackhide__ = True
+    outcome = yield
+    _pytest_raises_validation(item, outcome, 'raises')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,27 @@
+[tool:pytest]
+norecursedirs = build ve
+
+[coverage:run]
+data_file = .coverage
+include =
+    pytest_raises/pytest_raises.py
+    tests/test_raises.py
+
+[coverage:report]
+# NOTE: it appears that the manner in which pytest calls the pytest-raises
+#       code has the effect of confusing coverage.py.  One must be careful
+#       about skipping things like
+#
+#           def _pytest_fail_by_mark_or_set_excinfo
+#
+#       because that will skip the block introduced there, namely, coverage
+#       is not monitored for the entire function (not what we want).
+#
+#       This could be considered a bug, but isn't worth the time to fix.
+exclude_lines =
+    # The import statements are not relevant.
+    import
+    # Enable '# pragma: no cover' comments to skip line / block
+    pragma: no cover
+    # Skip `@pytest.hookimpl(hookwrapper=True)`
+    pytest\.hookimpl\(hookwrapper=True\)

--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,8 @@ def main():
         cmdclass            = {
             'sdist'         : CustomSDistCommand,
         },
+        # NOTE: if `install_requires` or `extras_require['develop']` change,
+        #       make sure to update the Dockerfile to install things.
         install_requires    = [
             'pytest>=3.2.2'
         ],

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ def main():
         extras_require      = {
             'develop'       : [
                 'pylint==1.7.2',
+                'pytest-cov'
             ],
         },
         packages            = [

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -1,11 +1,16 @@
 # -*- coding: utf-8 -*-
 
-def _run_tests_test(testdir, code, expected_output, expcted_return_code):
+def _run_tests_test(testdir, code, expected_output, expcted_return_code, conftest=None):
+    if conftest:
+        testdir.makeconftest(conftest)
     testdir.makepyfile(code)
     result = testdir.runpytest('-v')
     result.stdout.fnmatch_lines(expected_output)
     assert result.ret == expcted_return_code
 
+####################################################################################################
+# @pytest.mark.raises tests                                                                        #
+####################################################################################################
 def test_pytest_mark_raises_expected_exception(testdir):
     _run_tests_test(testdir, """
             import pytest
@@ -90,7 +95,131 @@ def test_pytest_mark_raises_unexpected_exception(testdir):
         """,
         [
             '*::test_pytest_mark_raises_unexpected_exception FAILED*',
-            '*AnotherException: the message',
+            # pylint: disable=line-too-long
+            "*ExpectedException: Expected exception of type <class '*SomeException'>, but got exception of type <class '*AnotherException'> with message: the message",
+        ],
+        1
+    )
+
+def test_pytest_mark_raises_not_an_exception(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            class NotAnException(object):
+                pass
+
+            @pytest.mark.raises(exception=NotAnException)
+            def test_pytest_mark_raises_not_an_exception():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_raises_not_an_exception FAILED*',
+            # pylint: disable=line-too-long
+            "PytestRaisesUsageError: @pytest.mark.raises: supplied `exception=<class '*NotAnException'>` is not a subclass of `BaseException`."
+
+        ],
+        1
+    )
+
+def test_pytest_mark_raises_not_an_exception_class(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.raises(exception=RuntimeError('bad'))
+            def test_pytest_mark_raises_not_an_exception_class():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_raises_not_an_exception_class FAILED*',
+            'PytestRaisesUsageError: @pytest.mark.raises: supplied `exception` argument must be a Class, e.g., `exception=RuntimeError`.'
+        ],
+        1
+    )
+
+def test_pytest_mark_raises_expected_message(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.raises(message='the message')
+            def test_pytest_mark_raises_expected_message():
+                raise RuntimeError('the message')
+        """,
+        [
+            '*::test_pytest_mark_raises_expected_message PASSED*'
+        ],
+        0
+    )
+
+def test_pytest_mark_raises_unexpected_message(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.raises(message='the message')
+            def test_pytest_mark_raises_unexpected_message():
+                raise RuntimeError('a different message')
+        """,
+        [
+            '*::test_pytest_mark_raises_unexpected_message FAILED*',
+            '*"the message" not in "a different message"*'
+        ],
+        1
+    )
+
+def test_pytest_mark_raises_expected_match(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.raises(match=r'.*Middle.*Road.*')
+            def test_pytest_mark_raises_expected_match():
+                raise RuntimeError('In The Middle Of The Road')
+        """,
+        [
+            '*::test_pytest_mark_raises_expected_match PASSED*',
+        ],
+        0
+    )
+
+def test_pytest_mark_raises_expected_match_with_flags(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+            import re
+
+            @pytest.mark.raises(match=r'.*middle.*road.*', match_flags=re.IGNORECASE)
+            def test_pytest_mark_raises_expected_match_with_flags():
+                raise RuntimeError('In The Middle Of The Road')
+        """,
+        [
+            '*::test_pytest_mark_raises_expected_match_with_flags PASSED*',
+        ],
+        0
+    )
+
+def test_pytest_mark_raises_unexpected_match(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.raises(match='^middle$')
+            def test_pytest_mark_raises_unexpected_match():
+                raise RuntimeError('In The Middle Of The Road')
+        """,
+        [
+            '*::test_pytest_mark_raises_unexpected_match FAILED*',
+            '*ExpectedMessage: "^middle$" does not match raised message "In The Middle Of The Road"'
+        ],
+        1
+    )
+
+def test_pytest_mark_raises_message_and_match_fails(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.raises(message='some message', match=r'stuff')
+            def test_pytest_mark_raises_message_and_match_fails():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_raises_message_and_match_fails FAILED*',
+            'PytestRaisesUsageError: @pytest.mark.raises: only `message="some message"` *OR* `match="stuff"` allowed, not both.'
         ],
         1
     )
@@ -131,6 +260,273 @@ def test_pytest_mark_raises_parametrize(testdir):
             '*::test_mark_raises*error7* PASSED*',
             '*::test_mark_raises*error8* FAILED*',
             '*ExpectedMessage: "other message" not in "the message"',
+        ],
+        1
+    )
+
+####################################################################################################
+# @pytest.mark.setup_raises tests                                                                  #
+####################################################################################################
+def test_pytest_mark_setup_raises_expected_exception(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises(exception = ValueError)
+            def test_mark_setup_raises_expected_exception():
+                pass
+        """,
+        [
+            '*::test_mark_setup_raises_expected_exception PASSED*',
+        ],
+        0,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise ValueError('the message')
+        """
+    )
+
+def test_pytest_mark_setup_raises_no_args(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises()
+            def test_mark_setup_raises_no_args():
+                pass
+        """,
+        [
+            '*::test_mark_setup_raises_no_args PASSED*',
+        ],
+        0,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise RuntimeError()
+        """
+    )
+
+def test_unmarked_test_setup(testdir):
+    _run_tests_test(testdir, """
+            def test_unmarked_test_setup():
+                pass
+        """,
+        [
+            '*::test_unmarked_test_setup ERROR*',
+        ],
+        1,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise RuntimeError()
+        """
+    )
+
+def test_pytest_mark_setup_raises_no_exception(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            class DifferentException(Exception):
+                pass
+
+            @pytest.mark.setup_raises(exception = DifferentException)
+            def test_pytest_mark_setup_raises_no_exception():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_no_exception FAILED*',
+            "*Expected exception <class '*.DifferentException'>, but it did not raise",
+        ],
+        1
+    )
+
+def test_pytest_mark_setup_raises_unexpected_exception(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            class SomeException(Exception):
+                pass
+
+            @pytest.mark.setup_raises(exception = SomeException)
+            def test_pytest_mark_setup_raises_unexpected_exception():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_unexpected_exception FAILED*',
+            # pylint: disable=line-too-long
+            "*ExpectedException: Expected exception of type <class '*SomeException'>, but got exception of type <class '*AnotherException'> with message: the message",
+        ],
+        1,
+        conftest="""
+            class AnotherException(Exception):
+                pass
+
+            def pytest_runtest_setup(item):
+                raise AnotherException('the message')
+        """
+    )
+
+def test_pytest_mark_setup_raises_not_an_exception(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            class NotAnException(object):
+                pass
+
+            @pytest.mark.setup_raises(exception=NotAnException)
+            def test_pytest_mark_setup_raises_not_an_exception():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_not_an_exception FAILED*',
+            # pylint: disable=line-too-long
+            "PytestRaisesUsageError: @pytest.mark.setup_raises: supplied `exception=<class '*NotAnException'>` is not a subclass of `BaseException`."
+
+        ],
+        1
+    )
+
+def test_pytest_mark_setup_raises_not_an_exception_class(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises(exception=RuntimeError('bad'))
+            def test_pytest_mark_setup_raises_not_an_exception_class():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_not_an_exception_class FAILED*',
+            # pylint: disable=line-too-long
+            'PytestRaisesUsageError: @pytest.mark.setup_raises: supplied `exception` argument must be a Class, e.g., `exception=RuntimeError`.'
+        ],
+        1
+    )
+
+def test_pytest_mark_setup_raises_unexpected_exception_fixture(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            class SomeException(Exception):
+                pass
+
+            class AnotherException(Exception):
+                pass
+
+            @pytest.fixture
+            def raise_me():
+                raise AnotherException('the message')
+
+            @pytest.mark.setup_raises(exception = SomeException)
+            def test_pytest_mark_setup_raises_unexpected_exception_fixture(raise_me):
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_unexpected_exception_fixture FAILED*',
+            '*AnotherException*with message: the message',
+        ],
+        1
+    )
+
+def test_pytest_mark_setup_raises_expected_message(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises(message='the message')
+            def test_pytest_mark_setup_raises_expected_message():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_expected_message PASSED*'
+        ],
+        0,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise RuntimeError('the message')
+        """
+    )
+
+def test_pytest_mark_setup_raises_unexpected_message(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises(message='the message')
+            def test_pytest_mark_setup_raises_unexpected_message():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_unexpected_message FAILED*',
+            '*"the message" not in "a different message"*'
+        ],
+        1,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise RuntimeError('a different message')
+        """
+    )
+
+def test_pytest_mark_setup_raises_expected_match(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises(match=r'.*Middle.*Road.*')
+            def test_pytest_mark_setup_raises_expected_match():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_expected_match PASSED*',
+        ],
+        0,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise RuntimeError('In The Middle Of The Road')
+        """
+    )
+
+def test_pytest_mark_setup_raises_expected_match_with_flags(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+            import re
+
+            @pytest.mark.setup_raises(match=r'.*middle.*road.*', match_flags=re.IGNORECASE)
+            def test_pytest_mark_setup_raises_expected_match_with_flags():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_expected_match_with_flags PASSED*',
+        ],
+        0,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise RuntimeError('In The Middle Of The Road')
+        """
+    )
+
+def test_pytest_mark_setup_raises_unexpected_match(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises(match='^middle$')
+            def test_pytest_mark_setup_raises_unexpected_match():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_unexpected_match FAILED*',
+            '*ExpectedMessage: "^middle$" does not match raised message "In The Middle Of The Road"'
+        ],
+        1,
+        conftest="""
+            def pytest_runtest_setup(item):
+                raise RuntimeError('In The Middle Of The Road')
+        """
+    )
+
+def test_pytest_mark_setup_raises_message_and_match_fails(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.setup_raises(message='some message', match=r'stuff')
+            def test_pytest_mark_setup_raises_message_and_match_fails():
+                pass
+        """,
+        [
+            '*::test_pytest_mark_setup_raises_message_and_match_fails FAILED*',
+            'PytestRaisesUsageError: @pytest.mark.setup_raises: only `message="some message"` *OR* `match="stuff"` allowed, not both.'
         ],
         1
     )


### PR DESCRIPTION
- [x] Update docker build to install things before source copy.
    - Fixes #12 (nested dependency cannot build without gcc and musl-dev on alpine image).
    - Means that `sudo make test` does not require the docker image to rebuild every time source is updated.
- [x] Add `setup_raises` marker, re-factor logic to be reused.
    - See below checklist.
- [x] Add `match=r"expr"` argument.  Being able to supply regular expressions is incredibly useful.
    - Very similar to `with pytest.raises(...)`, except explicit failure given if both `message` and `match` are provided.
        - I cannot think of a valid reason why you would ever need both at the same time.
        - Not allowing both makes logic for message testing easier.  If allowing both, which to you test?  Both `match` and `message`?  How do you format the `failure_message`?  Basically, force `message` or `match` not both can be removed, but need counsel on what you want when both supplied.
- [x] Add some testing coverage :tada:
    - Strange behavior with `import` statements, likely because of how `pytest` actually uses this plugin.
        - Attempts at mocking cannot rectify, see `setup.cfg`.
    - [See it in action!](https://travis-ci.org/Authentise/pytest-raises/jobs/442483204)  It was really useful to have this during this re-structure because there were previously many things I introduced that were never tested and now they are :slightly_smiling_face: 
    - [ ] Would you like to add an integration with something like https://codecov.io/ ?  It will basically always be at `98%` due to unknown coverage parsing, but hey that's pretty good :wink:
        - All you (or `Authentize`) need to do is enable the integration and I can add the badge and update `.travis.yml` to actually do the reporting.  Codecov isn't the only one, coveralls is popular, I just love the codecov interface / it's really easy to upload to.
- [ ] Update README to explain new additions (`match` and `setup_raises`).
    - I'm hoping to get some feedback on if what I'm proposing here is actually valid, instruction update pending discussion on [`pytest/#4175`](https://github.com/pytest-dev/pytest/issues/4175)

## How it All Works

This is also detailed thoroughly in the docstrings, but here's the overview of how it all works together.

1. Share as much code as possible between `raises` and `setup_raises` markers.
    - Hook impl executed (either `pytest_runtest_setup` for `setup_raises` or `pytest_runtest_call` for `raises` like usual).
    - `item`, `outcome`, and string `marker_name` indicating whether its coming from `setup` or `call` forwarded to `_pytest_raises_validation`.
2. If marker `setup_raises` or `raises` are found, there are now three distinct scenarios tested.
    - Case 1: test raised exception, and it `isinstance` of the expected exception class (either via `exception=ExceptionClass` or the default catch-all `Exception` if unspecified.
        - If the `message` or `match` are specified, the exception message is then validated.
        - If the `message` or `match` do not check out, `_pytest_fail_by_mark_or_set_excinfo` is called.
    - Case 2: test raised an exception, but it was of an unexpected type.
        - `_pytest_fail_by_mark_or_set_excinfo` fails the test.
    - Case 3: the test did not raise, but since it was marked with either `setup_raises` or `raises` test is failed using `_pytest_fail_by_mark_or_set_excinfo`.
3. Distinctions must be made between `setup_raises` and `raises`.  I don't understand the details (hence the `pytest` issue linked above), but basically there are problems with setting `outcome.excinfo` or calling `pytest.fail(...)`.
    - The distinctions between the two are made because we do not want tests to ERROR, we want them to FAIL.  See [`pytest/#4175`](https://github.com/pytest-dev/pytest/issues/4175) for details discovered by trial-and-error.
4. So to deal with this, I create a "handshake" using an intentionally obtusely named marker for the `setup_raises` so that tests properly FAIL rather than ERROR.  The general idea is: during `pytest_runtest_setup`, cases 1-3 are "flagged" with a secret marker, which is then checked for during `pytest_runtest_call`.  Search `secret_marker` in code.
5. Since (4) had to go down like this, I leveraged the same trick to also add some checks on things like is the `exception=???` actually valid, etc.

_I wouldn't go as far as to say the implementation is particularly clean, but it works reliably and I really need it.  This is the revisited implementation of what I was discussing in #9._

**There is a small concern.**  Consider the newly added `test_pytest_mark_setup_raises_unexpected_exception_fixture` in `test_raises.py`:

```py
import pytest

class SomeException(Exception):
    pass

class AnotherException(Exception):
    pass

@pytest.fixture
def raise_me():
    raise AnotherException('the message')

@pytest.mark.setup_raises(exception=SomeException)
def test_pytest_mark_setup_raises_unexpected_exception_fixture(raise_me):
    pass
```

**In any case where `setup_raises` is used, the test function body should be **empty** (just a single `pass` to compile).**  Logically, I cannot think of any scenario where if you expect `setup_raises` you also want to have an implementation in the test function.  But the implications are:

1. If you have testing code in the function body and are banking on your `setup` raising, this is a contradiction.
2. You therefore **cannot** mark a function with both `@pytest.mark.raises` _and_ `@pytest.mark.setup_raises`.  Only one is allowed -- you either are expecting the setup to fail, in which case the test body should be empty, or you want the test body to fail, in which case the test setup better not raise since you need a valid test setup.

-------------------------------------------------------------

Anyway, this is a big change and should definitely be reviewed.  I hesitated to put them all in one PR, but at the end of the day the docker / pylint fixes were needed for me to test things, and adding the `match` independently in the context of the changes for `setup_raises` would make for a guaranteed merge conflict between the two.

I look forward to updating / fixing / changing anything you need.  If you don't want this change in this repo then I'll package my own because I can't fully test my code without `setup_raises` :scream: