### PR TITLE
Missing 0.10 docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 - "3.7-dev"
 - "nightly"
 install:
-- pip install pip -U
+- pip install -U pip pytest
 - pip install -e .[develop]
 - pip install codecov
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add gcc musl-dev
 # dependencies, these must be updated as well!
 RUN mkdir -p /src/pytest-raises
 RUN python3 -m pip install pytest>=3.2.2
-RUN python3 -m pip install pylint==1.7.2
+RUN python3 -m pip install pylint
 RUN python3 -m pip install pytest-cov
 
 # Changes to source should have docker build cached up to here

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A [pytest][] plugin implementation of pytest.raises as a pytest.mark fixture.
 - [Installation](#installation)
 - [Usage](#usage)
     - [Available Markers](#available-markers)
+    - [Limitations on Markers](#limitations-on-markers)
     - [Available Parameters](#available-parameters)
     - [`@pytest.mark.raises` Examples](#pytestmarkraises-examples)
     - [`@pytest.mark.setup_raises` Examples](#pytestmarksetup_raises-examples)
@@ -20,7 +21,8 @@ A [pytest][] plugin implementation of pytest.raises as a pytest.mark fixture.
 Features
 --------
 
-Adds functionality for marking tests with a `pytest.mark.raises` fixture, which functions similarly to using `with pytest.raises`
+Adds functionality for marking tests with a `pytest.mark.raises` fixture, which
+functions similarly to using `with pytest.raises`
 
 
 Requirements
@@ -48,7 +50,8 @@ executes is **expected** to raise an error.  This is different from
 `@pytest.mark.xfail()` as it does not mean the test itself might fail, but
 instead that the "pass" for the test is that the code raises an error.
 
-It will allow tests which raise errors to pass.  The main usage is to assert that an error of a specific type is raise.
+It will allow tests which raise errors to pass.  The main usage is to assert
+that an error of a specific type is raise.
 
 If a test is marked with `@pytest.mark.raises` or
 `@pytest.mark.setup_raises` and it does **not** `raise` in the appropriate
@@ -64,6 +67,33 @@ This extension provides two markers for different phases of `pytest`:
       [`with pytest.raises(...)` context manager](https://docs.pytest.org/en/latest/assert.html#assertions-about-expected-exceptions).
 - `@pytest.mark.setup_raises`: for marking a function that should `raise`
   during the `pytest_runtest_setup` phase.
+
+### Limitations on Markers
+
+1. Any test function decorated with `@pytest.mark.setup_raises` is assumed
+   to have an empty function body
+
+   ```python
+   @pytest.mark.setup_raises()
+   def test_something():
+       pass
+   ```
+
+   This is because `pytest_runtest_call` may still be executed depending on
+   what raised when.  So any code in the test function body may cause
+   erroneous errors (particularly if you are using fixtures, since the
+   fixture setup may be incomplete).
+
+   See the [`@pytest.mark.setup_raises` Examples](#pytestmarksetup_raises-examples)
+   for more information.
+
+2. Since the function body of anything decorated with
+   `@pytest.mark.setup_raises` is assumed to be empty, test functions that
+   are decorated with both `@pytest.mark.raises`and
+   `@pytest.mark.setup_raises` is **not** supported.
+
+   The implementation details of this limitation are further documented in
+   the `_pytest_raises_validation` function.
 
 ### Available Parameters
 
@@ -201,7 +231,7 @@ In short: the chances are good that you will **not** need
 you need to verify failures during the `pytest_runtest_setup` phase, it is
 an invaluable tool.
 
-**Warning**: notice that when `@pytest.mark.setup_raises` is used, **the
+**Reminder**: notice that when `@pytest.mark.setup_raises` is used, **the
 function body should be exactly `pass`**.  The `pytest_runtest_setup` phase
 has raised, meaning the setup for the test is incomplete.  Anything other
 than an empty test function body of `pass` is **not** supported by this
@@ -210,13 +240,15 @@ extension.
 License
 -------
 
-Distributed under the terms of the [MIT][] license, "pytest-raises" is free and open source software.
+Distributed under the terms of the [MIT][] license, "pytest-raises" is free and
+open source software.
 
 
 Issues
 ------
 
-If you encounter any problems, please [file an issue][] along with a detailed description.
+If you encounter any problems, please [file an issue][] along with a detailed
+description.
 
 [MIT]: http://opensource.org/licenses/MIT
 [file an issue]: https://github.com/Authentise/pytest-raises/issues

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def main():
         ],
         extras_require      = {
             'develop'       : [
-                'pylint==1.7.2',
+                'pylint',
                 'pytest-cov'
             ],
         },

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -279,6 +279,44 @@ def test_pytest_mark_raises_parametrize(testdir):
         1
     )
 
+def test_pytest_raises_parametrize_demo(testdir):
+    _run_tests_test(testdir, """
+        import pytest
+
+        class SomeException(Exception):
+            pass
+
+        class AnotherException(Exception):
+            pass
+
+        @pytest.mark.parametrize('error', [
+            None,
+            pytest.param(
+                SomeException('the message'),
+                marks=pytest.mark.raises(exception=SomeException)
+            ),
+            pytest.param(
+                AnotherException('the message'),
+                marks=pytest.mark.raises(exception=AnotherException)
+            ),
+            pytest.param(
+                Exception('the message'),
+                marks=pytest.mark.raises()
+            )
+        ])
+        def test_mark_raises_demo(error):
+            if error:
+                raise error
+        """,
+        [
+            '*::test_mark_raises_demo*None* PASSED*',
+            '*::test_mark_raises_demo*error1* PASSED*',
+            '*::test_mark_raises_demo*error2* PASSED*',
+            '*::test_mark_raises_demo*error3* PASSED*'
+        ],
+        0
+    )
+
 ####################################################################################################
 # @pytest.mark.setup_raises tests                                                                  #
 ####################################################################################################
@@ -544,4 +582,35 @@ def test_pytest_mark_setup_raises_message_and_match_fails(testdir):
             'PytestRaisesUsageError: @pytest.mark.setup_raises: only `message="some message"` *OR* `match="stuff"` allowed, not both.'
         ],
         1
+    )
+
+
+def test_pytest_mark_setup_raises_demo(testdir):
+    _run_tests_test(testdir, """
+            import pytest
+
+            @pytest.mark.custom_marker(valid=False)
+            @pytest.mark.setup_raises(
+                exception=ValueError, match=r'.*was False$'
+            )
+            def test_mark_setup_raises_demo():
+                pass
+
+            @pytest.mark.custom_marker(valid=True)
+            def test_all_good():
+                pass
+        """,
+        [
+            '*::test_mark_setup_raises_demo PASSED*',
+            '*::test_all_good PASSED*'
+        ],
+        0,
+        conftest="""
+            def pytest_runtest_setup(item):
+                custom_marker = item.get_closest_marker('custom_marker')
+                if custom_marker:
+                    valid = custom_marker.kwargs.get('valid', True)
+                    if not valid:
+                        raise ValueError('custom_marker.valid was False')
+        """
     )

--- a/tests/test_raises.py
+++ b/tests/test_raises.py
@@ -236,14 +236,29 @@ def test_pytest_mark_raises_parametrize(testdir):
 
             @pytest.mark.parametrize('error', [
                 None,
-                pytest.mark.raises(SomeException('the message'), exception=SomeException),
-                pytest.mark.raises(AnotherException('the message'), exception=AnotherException),
-                pytest.mark.raises(Exception('the message')),
-                pytest.mark.raises(AnotherException('the message'), exception=SomeException),
+                pytest.param(
+                    SomeException('the message'), marks=pytest.mark.raises(exception=SomeException)
+                ),
+                pytest.param(
+                    AnotherException('the message'), marks=pytest.mark.raises(exception=AnotherException)
+                ),
+                pytest.param(
+                    Exception('the message'), marks=pytest.mark.raises()
+                ),
+                pytest.param(
+                    AnotherException('the message'), marks=pytest.mark.raises(exception=SomeException)
+                ),
                 SomeException('the message'),
-                pytest.mark.raises(None, exception=SomeException),
-                pytest.mark.raises(SomeException('the message'), exception=SomeException, message='the message'),
-                pytest.mark.raises(SomeException('the message'), exception=SomeException, message='other message'),
+                pytest.param(
+                    None, marks=pytest.mark.raises(exception=SomeException)
+                ),
+                pytest.param(
+                    SomeException('the message'), marks=pytest.mark.raises(exception=SomeException, message='the message')
+                ),
+                pytest.param(
+                    SomeException('the message'),
+                    marks=pytest.mark.raises(exception=SomeException, message='other message')
+                ),
             ])
             def test_mark_raises(error):
                 if error:


### PR DESCRIPTION
Continuation of #13 (I never documented the changes...and completely forgot sorry!).

- [X] Fixes #16 updated `parametrize` test case.
    - [X] Update docs on `parametrize` for how to do it in the new world order.
- [X] Document the new `setup_raises` (especially limitations).
- [X] Document the new `match` argument for `raises` and `setup_raises`.

@JamesMakela-NOAA @AetherUnbound regarding #16 [this commit](https://github.com/Lemmons/pytest-raises/commit/e3553943cb0491daaca94496451f0ec8c460c600) is what you are talking about right?  AKA parametrize can still be done, we just need to use the new way in the tests (and change the README documentation) right?