### PR TITLE
register raises/setup_raises as custom markers

### DIFF
--- a/pytest_raises/pytest_raises.py
+++ b/pytest_raises/pytest_raises.py
@@ -288,3 +288,20 @@ def pytest_runtest_call(item):
     __tracebackhide__ = True
     outcome = yield
     _pytest_raises_validation(item, outcome, 'raises')
+
+
+# NOTE: this gets evaluated by consuming packages only.
+def pytest_configure(config):  # pragma: no cover
+    """
+    Register the markers with pytest.
+
+    See: https://docs.pytest.org/en/latest/writing_plugins.html#registering-markers
+    """
+    config.addinivalue_line(
+        'markers',
+        'setup_raises: expect pytest_runtest_setup phase to raise.'
+    )
+    config.addinivalue_line(
+        'markers',
+        'raises: expect pytest_runtest_call phase to raise.'
+    )


### PR DESCRIPTION
Prevents PytestUnknownMarkWarning in consuming packages.

Currently:

```py
/tmp/tox/exhale/py/lib/python3.7/site-packages/_pytest/mark/structures.py:324
  /tmp/tox/exhale/py/lib/python3.7/site-packages/_pytest/mark/structures.py:324: PytestUnknownMarkWarning: Unknown pytest.mark.setup_raises - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
```

If I install `git+https://github.com/svenevs/pytest-raises.git@fix/register-markers-with-pytest` right now the warning will go away :slightly_smiling_face:

As noted, this never shows up in the tests locally.  I don't really know how to achieve that.  I also didn't add arguments (see [here](https://docs.pytest.org/en/latest/writing_plugins.html#registering-markers)), because the supported arguments for this package are variable and I think that makes things more confusing than it is worth.