### PR TITLE
Add "long_description_content_type"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ def main():
         description         = "An implementation of pytest.raises as a pytest.mark fixture",
         url                 = "https://github.com/Authentise/pytest-raises",
         long_description    = open('README.md').read(),
-        long_description_content_type='text/markdown', 
+        long_description_content_type='text/markdown',
         author              = "Authentise, Inc.",
         author_email        = "engineering@authentise.com",
         cmdclass            = {

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,7 @@ def main():
         description         = "An implementation of pytest.raises as a pytest.mark fixture",
         url                 = "https://github.com/Authentise/pytest-raises",
         long_description    = open('README.md').read(),
+        long_description_content_type='text/markdown', 
         author              = "Authentise, Inc.",
         author_email        = "engineering@authentise.com",
         cmdclass            = {


### PR DESCRIPTION
PyPi needs:

`long_description_content_type='text/markdown', `

to render Markdown long descriptions.

See: https://github.com/di/markdown-description-example/blob/master/setup.py