### PR TITLE
fix travis deployment repo target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ deploy:
     tags: true
     distributions: sdist bdist_wheel
     branch: master
-    repo: Authentise/pytest-raises
+    repo:  Lemmons/pytest-raises


### PR DESCRIPTION
> Skipping a deployment with the pypi provider because this repo's
> name does not match one specified in .travis.yml's
> deploy.on.repo: Authentise/pytest-raises

Failed to deploy on recently pushed (and now deleted) tag `0.11`.