### PR TITLE
temporary workaround to release 0.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,19 +56,21 @@ def _get_version_from_file():
 
 @contextlib.contextmanager
 def write_version():
-    version = _get_version_from_git()
-    if version:
-        with open(VERSION_FILE, 'r') as version_file:
-            old_contents = version_file.read()
-        with open(VERSION_FILE, 'w') as version_file:
-            new_contents = '__version__ = "{}"\n'.format(version)
-            version_file.write(new_contents)
-    print("Wrote {} with {}".format(VERSION_FILE, new_contents))
+    # TODO: don't use `git` on GitHub Actions, tags are not pulled
+    #       with history included (`git describe` will fail).
+    # version = _get_version_from_git()
+    # if version:
+    #     with open(VERSION_FILE, 'r') as version_file:
+    #         old_contents = version_file.read()
+    #     with open(VERSION_FILE, 'w') as version_file:
+    #         new_contents = '__version__ = "{}"\n'.format(version)
+    #         version_file.write(new_contents)
+    # print("Wrote {} with {}".format(VERSION_FILE, new_contents))
     yield
-    if version:
-        with open(VERSION_FILE, 'w') as version_file:
-            version_file.write(old_contents)
-            print("Reverted {} to old contents".format(VERSION_FILE))
+    # if version:
+    #     with open(VERSION_FILE, 'w') as version_file:
+    #         version_file.write(old_contents)
+    #         print("Reverted {} to old contents".format(VERSION_FILE))
 
 def get_version():
     file_version = _get_version_from_file()

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ def _get_version_from_file():
 
 @contextlib.contextmanager
 def write_version():
+    # pylint: disable=fixme
     # TODO: don't use `git` on GitHub Actions, tags are not pulled
     #       with history included (`git describe` will fail).
     # version = _get_version_from_git()


### PR DESCRIPTION
GitHub Actions does not download the whole history on tags.