### PR TITLE
Check out all history on Github Actions

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/setup.py
+++ b/setup.py
@@ -56,22 +56,19 @@ def _get_version_from_file():
 
 @contextlib.contextmanager
 def write_version():
-    # pylint: disable=fixme
-    # TODO: don't use `git` on GitHub Actions, tags are not pulled
-    #       with history included (`git describe` will fail).
-    # version = _get_version_from_git()
-    # if version:
-    #     with open(VERSION_FILE, 'r') as version_file:
-    #         old_contents = version_file.read()
-    #     with open(VERSION_FILE, 'w') as version_file:
-    #         new_contents = '__version__ = "{}"\n'.format(version)
-    #         version_file.write(new_contents)
-    # print("Wrote {} with {}".format(VERSION_FILE, new_contents))
+    version = _get_version_from_git()
+    if version:
+        with open(VERSION_FILE, 'r') as version_file:
+            old_contents = version_file.read()
+        with open(VERSION_FILE, 'w') as version_file:
+            new_contents = '__version__ = "{}"\n'.format(version)
+            version_file.write(new_contents)
+    print("Wrote {} with {}".format(VERSION_FILE, new_contents))
     yield
-    # if version:
-    #     with open(VERSION_FILE, 'w') as version_file:
-    #         version_file.write(old_contents)
-    #         print("Reverted {} to old contents".format(VERSION_FILE))
+    if version:
+        with open(VERSION_FILE, 'w') as version_file:
+            version_file.write(old_contents)
+            print("Reverted {} to old contents".format(VERSION_FILE))
 
 def get_version():
     file_version = _get_version_from_file()


### PR DESCRIPTION
Possible fix for #26 - the `actions/checkout@v2` was optimized for efficiency but this is a pretty small repo so checking out the entire history is probably fine. I'm not sure if there's a best way to test this besides running another deploy... unfortunately. I'm also uncertain if this will also fetch all tags or if this only pulls the commits.